### PR TITLE
Public OraErr

### DIFF
--- a/drv.go
+++ b/drv.go
@@ -594,22 +594,22 @@ func ParseConnString(connString string) (ConnectionParams, error) {
 	return P, nil
 }
 
-type oraErr struct {
+type OraErr struct {
 	code    int
 	message string
 }
 
-func (oe *oraErr) Code() int       { return oe.code }
-func (oe *oraErr) Message() string { return oe.message }
-func (oe *oraErr) Error() string {
+func (oe *OraErr) Code() int       { return oe.code }
+func (oe *OraErr) Message() string { return oe.message }
+func (oe *OraErr) Error() string {
 	msg := oe.Message()
 	if oe.code == 0 && msg == "" {
 		return ""
 	}
 	return fmt.Sprintf("ORA-%05d: %s", oe.code, oe.message)
 }
-func fromErrorInfo(errInfo C.dpiErrorInfo) *oraErr {
-	oe := oraErr{
+func fromErrorInfo(errInfo C.dpiErrorInfo) *OraErr {
+	oe := OraErr{
 		code:    int(errInfo.code),
 		message: strings.TrimSpace(C.GoString(errInfo.message)),
 	}
@@ -631,7 +631,7 @@ func newErrorInfo(code int, message string) C.dpiErrorInfo {
 // against deadcode
 var _ = newErrorInfo
 
-func (d *drv) getError() *oraErr {
+func (d *drv) getError() *OraErr {
 	var errInfo C.dpiErrorInfo
 	C.dpiContext_getError(d.dpiContext, &errInfo)
 	return fromErrorInfo(errInfo)

--- a/drv_test.go
+++ b/drv_test.go
@@ -23,7 +23,7 @@ func TestFromErrorInfo(t *testing.T) {
 	errInfo := newErrorInfo(0, "ORA-24315: érvénytelen attribútumtípus\n")
 	t.Log("errInfo", errInfo)
 	oe := fromErrorInfo(errInfo)
-	t.Log("oraErr", oe)
+	t.Log("OraErr", oe)
 	if oe.Code() != 24315 {
 		t.Errorf("got %d, wanted 24315", oe.Code())
 	}


### PR DESCRIPTION
Hello

In my opinion I think it's better that 'oraErr' be a public struct, since that way you can make decisions depending on the type of error.

If you are building an API and in an Oracle request returns an 'ORA-00021' (session attached to some other process; can not switch session) you can return an error 500 to the client, however if Oracle returns 'ORA-00018' (maximum number of sessions exceeded) would be better to return for example a 403. This is simply the first example that has occurred to me, but surely there are more and better.

In order to take decisions based on the error that Oracle returns, it is necessary to cast the error to 'oraErr' (to be sure that the error is a Oracle database error) and then access the code.

If it is true that you could do something like:

`
if someOraError, ok := err.(interface { Code() int} ); ok {
      return someOraError.Code()
}
 `

But this solution from my point of view is not clean and also does not ensure that the error comes from an Oracle database.