### PR TITLE
maybeBadConn: Support ORA-12609 and ORA-03135 errors.

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -310,7 +310,8 @@ func maybeBadConn(err error) error {
 	}); ok {
 		// Yes, this is copied from rana/ora, but I've put it there, so it's mine. @tgulacsi
 		switch cd.Code() {
-		case 1012, 3113, 3114, 12170, 12528, 12545, 12547, 24315, 28547:
+		case 12609, 1012, 3113, 3114, 12170, 12528, 12545, 12547, 24315, 28547, 03135:
+			// ORA-12609: TNS:Receive timeout occurred
 			// ORA-01012: Not logged on
 			// ORA-03113: end-of-file on communication channel
 			// ORA-03114: not connected to ORACLE
@@ -320,6 +321,7 @@ func maybeBadConn(err error) error {
 			// ORA-12547: TNS:lost contact
 			// ORA-24315: illegal attribute type
 			// ORA-28547: connection to server failed, probable Oracle Net admin error
+			// ORA-03135: connection lost contact
 			return driver.ErrBadConn
 		}
 	}


### PR DESCRIPTION
Hello,

This patch should help handle 2 additional network-related error codes that I have encountered in testing and production for the latest version of Oracle.

I have some general, unrelated thoughts in this area. I can file a separate issue for this piece of you would like, so that we can discuss how to approach it (if you approve):

When network connections drop, the automatic reconnect is silent -- the calling code has no visibility into this. It would be nice to be able to track this somehow as a programmer -- into Prometheus, or oklog, Graylog, Kibana, etc.

Can we add a function pointer that the client programmer can set, so that tracing or logging this information can be implemented in a service that wraps Goracle? Or would you advise just disabling reconnects and implementing it by hand that way? Thanks!

Cheers,

