### PR TITLE
Remove odpi-c submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "odpi"]
-	path = odpi-c
-	url = https://github.com/oracle/odpi

--- a/odpi/README.md
+++ b/odpi/README.md
@@ -1,4 +1,4 @@
-# ODPI-C version 2.2.0
+# ODPI-C version 2.2.0 ([@dd385e9](https://github.com/oracle/odpi/tree/dd385e9cb984cdd7ab86af54752fb9529e0109b5))
 
 Oracle Database Programming Interface for C (ODPI-C) is an open source library
 of C code that simplifies access to Oracle Database for applications written in


### PR DESCRIPTION
Removing the odpi-c submodule due to:

1) It's redundant now that it's embedded into the project
2) Having two references to it in project makes it impossible to be used with dep (adding it from gopkg.in with dep silently ignores errors giving you 2.1.17, which I think when odpi was embedded, instead of the latest)

Related: https://github.com/golang/dep/issues/1633