### PR TITLE
Add support for named timezones during parsing

### DIFF
--- a/drv.go
+++ b/drv.go
@@ -908,6 +908,23 @@ func parseTZ(s string) (int, error) {
 		}
 		s = s[:i]
 	}
+	if i := strings.IndexByte(s, '/'); i >= 0 {
+		destLoc, err := time.LoadLocation("UTC")
+		if err != nil {
+			return tz, errors.Wrap(err,s)
+		}
+		targetLoc, err := time.LoadLocation(s)
+		if err != nil {
+			return tz, errors.Wrap(err,s)
+		}
+
+		now := time.Now()
+		_, destOffset := now.In(destLoc).Zone()
+		_, localOffset := now.In(targetLoc).Zone()
+
+		tz+= localOffset-destOffset
+		return tz, nil
+	}
 	if i64, err := strconv.ParseInt(s, 10, 5); err != nil {
 		return tz, errors.Wrap(err, s)
 	} else {


### PR DESCRIPTION
Accoring to Oracle documentation the query 'SELECT DBTIMEZONE FROM DUAL' can result in either a offset or a region name, depending on how the timezone was specified during database creation. See: https://docs.oracle.com/cd/B19306_01/server.102/b14200/functions039.htm

This PR will implement support for parsing named timezones like 'Europe/Brussels'. The time package is used to implement this.