### PR TITLE
 Fix connection leak and memory leak in ExecContext and QueryContext

### DIFF
--- a/stmt.go
+++ b/stmt.go
@@ -379,7 +379,7 @@ func (st *statement) ExecContext(ctx context.Context, args []driver.NamedValue) 
 				Log("msg", "BREAK statement")
 			}
 			_ = st.Break()
-			st.close(true)
+			st.close(false)
 			if err := st.conn.Close(); err != nil {
 				return nil, err
 			}
@@ -539,7 +539,7 @@ func (st *statement) QueryContext(ctx context.Context, args []driver.NamedValue)
 				Log("msg", "BREAK query")
 			}
 			_ = st.Break()
-			st.close(true)
+			st.close(false)
 			if err := st.conn.Close(); err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
 Don't keep statement When context timeout or is canceled, or
 the dpiVars wouldn't released and connection wouldn't released.

 As dpiStmt_bindByPos bind the dpiVars to statement, if not release
 the statement, the dpiVars wouldn't really be released.

 As dpiConn_newVar bind the dpiVar to the connection, if not release the
 dpiVar, the connection wouldn't really be released.