### PR TITLE
Close and release dpiConn to avoid memory leak

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -147,7 +147,7 @@ func (c *conn) Close() error {
 	}
 	c.Lock()
 	defer c.Unlock()
-	return c.close(false)
+	return c.close(true)
 }
 
 func (c *conn) close(doNotReuse bool) error {
@@ -177,6 +177,7 @@ func (c *conn) close(doNotReuse bool) error {
 	}()
 	var rc C.int
 	if doNotReuse {
+		defer C.dpiConn_release(dpiConn)
 		rc = C.dpiConn_close(dpiConn, C.DPI_MODE_CONN_CLOSE_DROP, nil, 0)
 	} else {
 		rc = C.dpiConn_release(dpiConn)
@@ -712,7 +713,7 @@ func (c *conn) ensureContextUser(ctx context.Context) error {
 	}
 
 	if c.dpiConn != nil {
-		if err := c.Close(); err != nil {
+		if err := c.close(false); err != nil {
 			return driver.ErrBadConn
 		}
 	}

--- a/orahlp.go
+++ b/orahlp.go
@@ -57,7 +57,7 @@ func DescribeQuery(ctx context.Context, db Execer, qry string) ([]QueryColumn, e
 	if err != nil {
 		return nil, err
 	}
-	defer c.Close()
+	defer c.close(false)
 
 	stmt, err := c.PrepareContext(ctx, qry)
 	if err != nil {


### PR DESCRIPTION
"database/sql/driver" call conn.Close() to put idle (or maxLifetime) connections back to the pool. To avoid memory leak, dpiConn_release must be invoked.