### PR TITLE
segmentation violation on close objectType twice

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -160,7 +160,13 @@ func (c *conn) close(doNotReuse bool) error {
 	if dpiConn == nil {
 		return nil
 	}
+	seen := make(map[string]struct{}, len(objTypes))
 	for _, o := range objTypes {
+        nm := o.FullName()
+        if _, seen := seen[nm]; seen {
+            continue
+        }
+        seen[nm] = struct{}{}
 		o.close()
 	}
 	// Just to be sure, break anything in progress.

--- a/obj.go
+++ b/obj.go
@@ -409,7 +409,8 @@ func (c *conn) GetObjectType(name string) (ObjectType, error) {
 		if c.objTypes == nil {
 			c.objTypes = make(map[string]ObjectType)
 		}
-		c.objTypes[name] = t		
+		c.objTypes[name] = t
+		c.objTypes[t.FullName()] = t
 	}
 	return t, err
 }

--- a/obj.go
+++ b/obj.go
@@ -409,8 +409,7 @@ func (c *conn) GetObjectType(name string) (ObjectType, error) {
 		if c.objTypes == nil {
 			c.objTypes = make(map[string]ObjectType)
 		}
-		c.objTypes[name] = t
-		c.objTypes[t.FullName()] = t
+		c.objTypes[name] = t		
 	}
 	return t, err
 }


### PR DESCRIPTION
Getting segmentation violation if release same dpi_objectType twice before dpi_connClose.

[signal SIGSEGV: segmentation violation code=0x1 addr=0xa4 pc=0xa58ce9]